### PR TITLE
update webpack-hud 0.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,6 @@
     "url-loader": "^0.5.7",
     "webpack": "1.13.0",
     "webpack-dev-server": "~1.14.1",
-    "webpack-hud": "0.0.8"
+    "webpack-hud": "0.0.9"
   }
 }


### PR DESCRIPTION
用 `virtual-dom` 替换了 `diffhtml`. MIUI 原生浏览器测试通过.