### PR TITLE
Update is-installed.js

### DIFF
--- a/packages/cooking-cli/util/is-installed.js
+++ b/packages/cooking-cli/util/is-installed.js
@@ -1,8 +1,8 @@
 'use strict'
-
+const cp=require('child_process')
 module.exports = name => {
   try {
-    require.resolve(name)
+    cp.execSync("node -e require.resolve('" + name + "')", { stdio: 'ignore' });
 
     return true
   } catch (_) {


### PR DESCRIPTION
执行`require.resolve`会设置模块查找中的`stat.cache`缓存，从而导致在同一node进程中，即使下文安装了指定模块，也无法找到指定的模块。因此使用子进程来防止设置当前进程的`stat.cache`。详见: https://github.com/nodejs/node/issues/12695


