### PR TITLE
Config webpack-dev-server to 2.7.x for Browsers that do not support ES6.

### DIFF
--- a/packages/cooking-cli/package.json
+++ b/packages/cooking-cli/package.json
@@ -63,7 +63,7 @@
     "update-notifier": "^1.0.2",
     "url-loader": "^0.5.7",
     "webpack": "^2.2.0",
-    "webpack-dev-server": "^2.2.0",
+    "webpack-dev-server": "~2.7.0",
     "webpack-hud": "*"
   }
 }


### PR DESCRIPTION
Please see: https://github.com/webpack/webpack-dev-server/issues/1104

Specific case: `webpack-dev-server` 2.8.x in iOS 9.3.3 Safari

ES6 codes of `webpack-dev-server/client/index.js`  will be injected to browser,
then throw Error: "Const declarations are not supported in strict mode."